### PR TITLE
Added a teacher profile page

### DIFF
--- a/Dev/QConnect/src/components/TopBanner.js
+++ b/Dev/QConnect/src/components/TopBanner.js
@@ -43,11 +43,11 @@ class TopBanner extends FontLoadingComponent {
 
 //Verifies the propTypes are correct
 TopBanner.propTypes = {
-    Icon1Name: PropTypes.string.isRequired,
-    Icon1OnPress: PropTypes.func.isRequired,
-    Title: PropTypes.string.isRequired,
-    Icon2Name: PropTypes.string.isRequired,
-    Icon2OnPress: PropTypes.func.isRequired
+    Icon1Name: PropTypes.string,
+    Icon1OnPress: PropTypes.func,
+    Title: PropTypes.string,
+    Icon2Name: PropTypes.string,
+    Icon2OnPress: PropTypes.func,
 }
 
 const styles = StyleSheet.create({

--- a/Dev/QConnect/src/screens/FirstRun/FirstRunNavigator.js
+++ b/Dev/QConnect/src/screens/FirstRun/FirstRunNavigator.js
@@ -1,5 +1,5 @@
-import { createStackNavigator, createAppContainer } from 'react-navigation'
-import FirstRunScreen from './FirstRunScreen'
+import { createStackNavigator, createAppContainer, DrawerActions } from 'react-navigation';
+import FirstRunScreen from './FirstRunScreen';
 import TeacherMenu from '../TeacherScreens/TeacherMenu';
 
 const routeConfig = {
@@ -8,12 +8,12 @@ const routeConfig = {
     },
     TeacherScreens: {
         screen: TeacherMenu
-  }
+    }
 }
 
 const navigatorConfig = {
     headerMode: 'none',
-  }
+}
 
 const FirstRunStackNavigator = createStackNavigator(routeConfig, navigatorConfig);
 

--- a/Dev/QConnect/src/screens/FirstRun/FirstRunScreen.js
+++ b/Dev/QConnect/src/screens/FirstRun/FirstRunScreen.js
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-    View, 
-    Text, 
-    StyleSheet, 
-    Dimensions, 
-    ImageBackground} from 'react-native';
+import { View, StyleSheet, Dimensions, ImageBackground} from 'react-native';
 import QcActionButton from 'components/QcActionButton'
 import QcAppBanner from 'components/QcAppBanner'
 
@@ -19,7 +14,7 @@ class FirstRunScreen extends React.Component {
         this.props.navigation.navigate('TeacherScreens');
     }
 
-    render(){
+    render() {
         const { navigation } = this.props;
         return (
           <View style={styles.container}>

--- a/Dev/QConnect/src/screens/TeacherScreens/AddClass/AddClassNavigator.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/AddClass/AddClassNavigator.js
@@ -1,23 +1,20 @@
 import React from 'react';
-import { createStackNavigator } from 'react-navigation';
+import { createStackNavigator, DrawerActions } from 'react-navigation';
 import { Icon } from 'react-native-elements';
-
 import AddClassScreen from './AddClassScreen';
+import TopBanner from 'components/TopBanner';
 
 const AddClassNavigator = createStackNavigator({
   AddClass: {
     screen: AddClassScreen,
     navigationOptions: ({ navigation }) => ({
-      title: 'Add a new class',
-      headerLeft: (
-        <Icon
-          name="menu"
-          size={30}
-          type="entypo"
-          iconStyle={{ paddingLeft: 10 }}
-          onPress={() => navigation.openDrawer()}
+      header: (
+        <TopBanner
+          Icon1Name="navicon"
+          Icon1OnPress={() => navigation.openDrawer()}
+          Title="Add a new class"
         />
-      ),
+      )
     }),
   },
 },

--- a/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassHeaderNavigator.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassHeaderNavigator.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import TopBanner from 'components/TopBanner'
-import { createStackNavigator } from 'react-navigation';
+import { createStackNavigator, DrawerActions } from 'react-navigation';
 import ClassTabsNavigator from './ClassTabsNavigator';
 import StudentProfileScreen from 'screens/StudentProfile/StudentProfileScreen';
 import ClassEditScreen from 'screens/TeacherScreens/ClassTabs/ClassEditScreen';
@@ -13,7 +13,7 @@ const ClassHeaderNavigator = createStackNavigator({
         <TopBanner
           Icon1Name="navicon"
           Icon1OnPress={() => navigation.openDrawer()}
-          Title="Quran Class"
+          Title="Monday Class"
           Icon2Name="edit"
           Icon2OnPress={() => navigation.navigate('ClassEdit')}
         />

--- a/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassTabsNavigator.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassTabsNavigator.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createBottomTabNavigator, createAppContainer} from 'react-navigation';
+import {createBottomTabNavigator, createAppContainer, DrawerActions} from 'react-navigation';
 import colors from 'config/colors';
 import { Icon } from 'react-native-elements';
 import ClassMainScreen from './ClassMainScreen';

--- a/Dev/QConnect/src/screens/TeacherScreens/TeacherMenu.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/TeacherMenu.js
@@ -1,46 +1,37 @@
-import {createDrawerNavigator, createAppContainer, DrawerActions} from 'react-navigation';
 import React from 'react';
+import {createDrawerNavigator, createAppContainer} from 'react-navigation';
 import { Icon } from 'react-native-elements';
 import AddClassNavigator from './AddClass/AddClassNavigator';
 import ClassHeaderNavigator from './ClassTabs/ClassHeaderNavigator';
+import TeacherProfileNavigator from './TeacherProfile/TeacherProfileNavigator';
 
 const routeConfig = {
- CurrentClass: {
+  TeacherProfile: {
+    screen: TeacherProfileNavigator,
+    navigationOptions: ({ navigation }) => ({
+      title: 'Mrs. Eslam',
+    })
+  },
+  //Todo: The drawer must be dynamic and must map out all of the classes and display them in
+  //the drawer options
+  CurrentClass: {
     screen: ClassHeaderNavigator,
     path: 'teacher/class/tabs', //todo: the path should have class id as a param to be unique
     navigationOptions: ({ navigation }) => ({
         title: 'Monday Class',
-        headerLeft: (
-          <Icon
-            name="menu"
-            size={30}
-            type="entypo"
-            iconStyle={{ paddingLeft: 10 }}
-            onPress={() => navigation.openDrawer()}
-          />
-        ),
-      }),
- },
- AddClass: {
-  screen: AddClassNavigator,
-  path: 'teacher/class/new',
-  navigationOptions: ({ navigation }) => ({
-     title: 'Add new class',
-     headerLeft: (
-       <Icon
-         name="menu"
-         size={30}
-         type="entypo"
-         iconStyle={{ paddingLeft: 10 }}
-         onPress={() => navigation.openDrawer()}
-       />
-     ),
-   }),
-}
+    }),
+  },
+  AddClass: {
+    screen: AddClassNavigator,
+    path: 'teacher/class/new',
+    navigationOptions: ({ navigation }) => ({
+      title: 'Add new class',
+    }),
+  }
 };
 
 const navigationConfig = {
-    drawerWidth: 300,
+    drawerWidth: 325,
     drawerPosition: 'left',
     drawerOpenRoute: 'DrawerOpen',
     drawerCloseRoute: 'DrawerClose',

--- a/Dev/QConnect/src/screens/TeacherScreens/TeacherProfile/TeacherProfileNavigator.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/TeacherProfile/TeacherProfileNavigator.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { createStackNavigator } from 'react-navigation';
+import { Icon } from 'react-native-elements';
+import TeacherProfileScreen from './TeacherProfileScreen';
+import TopBanner from 'components/TopBanner';
+
+const TeacherProfileNavigator = createStackNavigator({
+    TeacherProfile: {
+        screen: TeacherProfileScreen,
+        navigationOptions: ({ navigation }) => ({
+            header: (
+                <TopBanner
+                  Icon1Name="navicon"
+                  Icon1OnPress={() => navigation.openDrawer()}
+                  Title="My Profile"
+                />
+            )
+        })
+    }
+},
+{
+    drawerLabel: 'My Profile',
+    drawerIcon: ({ tintColor }) => (
+        <Icon
+          name="plus"
+          size={30}
+          iconStyle={{
+            width: 30,
+            height: 30,
+          }}
+          type="material"
+          color={tintColor}
+        />
+      ),
+});
+
+export default TeacherProfileNavigator;

--- a/Dev/QConnect/src/screens/TeacherScreens/TeacherProfile/TeacherProfileScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/TeacherProfile/TeacherProfileScreen.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+import { Text, View } from 'react-native';
+
+class TeacherProfileScreen extends Component {
+    render() {
+        return(
+            <View>
+                <Text>Teacher profile placeholder</Text>
+            </View>
+        )
+    }
+}
+
+export default TeacherProfileScreen;
+


### PR DESCRIPTION
I added a teacher profile page that contains nothing at the moment, but the intent is for the teacher to be able to edit their profile pic, name, and other personal info. I also refactored the TopBanner component so it can work with some of the screens we need. An issue I was unable to resolve and would like for someone else to look at is trying to get the "I am a teacher" button on the FirstRunScreen to link to the ClassMainScreen and not the TeacherProfile. It seems that currently, the FirstRunNavigator is directed towards the TeacherMenu drawer, and React Native stupidly chose to have the drawers link to the first element in the drawer, which in our case is the Teacher Profile. I kept running into errors when I tried to reroute the FirstRunScreen button to the ClassHeaderNavigator, so I left it as is in the hope that someone else will see something I'm missing. Take a look at my code and give me any feedback.