### PR TITLE
Update AttendanceScreen to make the tests independent of today's date

### DIFF
--- a/Dev/QConnect/__tests__/__snapshots__/TeacherScreens.snapshot.test.js.snap
+++ b/Dev/QConnect/__tests__/__snapshots__/TeacherScreens.snapshot.test.js.snap
@@ -793,7 +793,7 @@ exports[`Teacher screens snapshots render ClassAttendanceScreen 1`] = `
                       >
                         <RCTDatePicker
                           date={1552719600000}
-                          maximumDate={1554620400000}
+                          maximumDate={1552719600000}
                           mode="date"
                           onChange={[Function]}
                           onResponderTerminationRequest={[Function]}

--- a/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassAttendanceScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassAttendanceScreen.js
@@ -14,10 +14,10 @@ import strings from 'config/strings';
 //const { directions: { SWIPE_UP, SWIPE_LEFT, SWIPE_DOWN, SWIPE_RIGHT } } = swipeable;
 
 export class ClassAttendanceScreen extends Component {
-
+    todaysDate = this.props.defaultDate ? this.props.defaultDate : new Date().toLocaleDateString("en-US")
     state = {
         selectedStudents: [],
-        selectedDate: this.props.defaultDate ? this.props.defaultDate : new Date().toLocaleDateString("en-US")
+        selectedDate: this.todaysDate
     }
 
     //This method will set the student selected property to the opposite of whatever it was
@@ -120,7 +120,7 @@ export class ClassAttendanceScreen extends Component {
                     format="MM-DD-YYYY"
                     duration={300}
                     style={{paddingLeft: 15}}
-                    maxDate={new Date().toLocaleDateString("en-US")}
+                    maxDate={this.todaysDate}
                     customStyles={{dateInput: {borderColor: colors.lightGrey}}}
                     onDateChange={(date) => this.getAttendance(date)}
                     />


### PR DESCRIPTION
Make the snapshot tests deterministic by having Maximum
date property also accepts a custom date if passed in as a props (only in the case of tests)