### PR TITLE
Pressing on Edit assignment pre-populate the input dialog with the as…

### DIFF
--- a/Dev/QConnect/src/screens/Evaluation/EvaluationPage.js
+++ b/Dev/QConnect/src/screens/Evaluation/EvaluationPage.js
@@ -33,7 +33,10 @@ export class EvaluationPage extends Component {
   //------------  Saves the rating to db and pops to previous view
   submitRating(classIndex, studentIndex) {
     this.props.completeCurrentAssignment(classIndex, studentIndex, this.state);
-    this.props.editCurrentAssignment(classIndex, studentIndex, { name: strings.None, startDate: "" });
+
+    // keep the assignment name as the last assignment to reduce retype since most of the times the next assignment would be the same surah (next portion) or a redo.
+    // todo: eventually right after grading we should have a step for the teacher to update the next assignment
+    this.props.editCurrentAssignment(classIndex, studentIndex, { name: this.props.currentAssignment.name, startDate: "" });
     this.props.navigation.pop();
   }
 

--- a/Dev/QConnect/src/screens/StudentProfile/StudentProfileScreen.js
+++ b/Dev/QConnect/src/screens/StudentProfile/StudentProfileScreen.js
@@ -63,13 +63,14 @@ class StudentProfileScreen extends FontLoadingComponent {
     //the rating will default to 0.
     averageRating = currentStudent.totalAssignments === 0 ? 0.0 :
       (currentStudent.totalGrade / currentStudent.totalAssignments);
+    const dialogInitialText =  currentStudent.currentAssignment.name === 'None' ? {hintInput: strings.EnterAssignmentHere} : {initValueTextInput: currentStudent.currentAssignment.name} 
 
     return (
       <View style={styles.container}>
         <DialogInput
           isDialogVisible={this.state.isDialogVisible}
           title={strings.EditAssignment}
-          hintInput={strings.EnterAssignmentHere}
+          {...dialogInitialText}
           dialogStyle={{ marginBottom: 100 }}
           submitInput={(inputText) =>
           //If the student already has an existing assignment, then it will simply edit the


### PR DESCRIPTION
2 Changes:

1. In student profile page, changed the assignment dialog input's text to default to the current assignment for ease of updates 

2. In EvaluationPage, submitting a grade does not reset the assignment text (for ease of update next portion)
-- Context ---
1- Currently, when  a teacher presses edit assignment, the dialog is empty. Usually teachers edit the current assignment to either correct a typo or modify the next potion, which is usually very close to the previous portion (next verse, page, etc..), so it helps a lot if the text is prepopulated with the current assignment

2- This has been one of the major issues for me so far: when I submit a grade, I have to retype the assignment again. When I grade tasmee3 for my kids, they usually either keep working on the same page the next few days, or the next portion is very similar (next page, etc..) it helps a lot to keep the current assignment text so all I need to do is change page number or in many cases it actually the same (Nouha keeps working on Al-Moursalat all the past couple of weeks, it never changes, even though she makes tasmee3 every day)