### PR TITLE
Some enhancements to the getRatingCaption method

### DIFF
--- a/Dev/QConnect/src/screens/StudentProfile/StudentProfileScreen.js
+++ b/Dev/QConnect/src/screens/StudentProfile/StudentProfileScreen.js
@@ -55,19 +55,19 @@ class StudentProfileScreen extends QcParentScreen {
   }
 
   getRatingCaption() {
-    if(averageRating >4 ){
-      strings.OutStanding = strings.OutStanding
+    let caption = strings.GetStarted;
+
+    if(averageRating > 4 ){
+      caption = strings.OutStanding
     }
-    else if (averageRating > 3){
-      strings.OutStanding = strings.GreatJob
+    else if (averageRating >= 3){
+      caption = strings.GreatJob
     }
     else if (averageRating > 0){
-      strings.OutStanding = strings.PracticePerfect
+      caption = strings.PracticePerfect
     }
-    else{
-      strings.OutStanding = strings.GetStarted
-    }
-    return strings.OutStanding
+
+    return caption
   }
 
   //---------- main UI render ===============================


### PR DESCRIPTION
the original code was using stings.Outstanding constant as the name of the caption variable.. Changed it to a proper variable name so it doesn't get confused with the strings.Outstanding constant.

I also made a grade 3.0 part of a "Grat Job" caption instead of "Practice Makes Perfect"