### PR TITLE
Change tracking screen names logic

### DIFF
--- a/Dev/QConnect/src/screens/Evaluation/EvaluationPage.js
+++ b/Dev/QConnect/src/screens/Evaluation/EvaluationPage.js
@@ -15,13 +15,13 @@ import QcParentScreen from 'screens/QcParentScreen';
 
 export class EvaluationPage extends QcParentScreen {
 
+  name = "EvaluationPage";
+
   // -------------  Current evaluation state ---------------------
   state = {
     overallGrade: 0,
     notes: ""
   }
-
-  myname = this.constructor.name;
 
   // --------------  Updates state to reflect a change in a category rating --------------
   updateCategoryRating = (name, rating) => {
@@ -116,7 +116,7 @@ export class EvaluationPage extends QcParentScreen {
             <QcActionButton
               text={strings.Submit}
               onPress={() => { this.submitRating(classIndex, studentIndex) }}
-              screen={this.constructor.name}
+              screen={this.name}
             />
           </View>
           <View style={styles.filler}></View>

--- a/Dev/QConnect/src/screens/FirstRun/FirstRunScreen.js
+++ b/Dev/QConnect/src/screens/FirstRun/FirstRunScreen.js
@@ -12,6 +12,8 @@ const BG_IMAGE = require('assets/images/read_child_bg.jpg');
 
 class FirstRunScreen extends QcParentScreen {
 
+    name = "FirstRunScreen";
+
     onTeacherFlow = () => {
       //todo: get the first class to show from redux persist (current class)
         this.props.navigation.push('TeacherWelcomeScreen', { classIndex: 0, classTitle: "Quran Class"});
@@ -28,7 +30,7 @@ class FirstRunScreen extends QcParentScreen {
                         navigation={navigation}
                         text={strings.IAmATeacher}
                         onPress={this.onTeacherFlow}
-                        screen={this.constructor.name} />
+                        screen={this.name} />
                 </ImageBackground>
             </View>  
         );

--- a/Dev/QConnect/src/screens/FirstRun/TeacherWelcomeScreen.js
+++ b/Dev/QConnect/src/screens/FirstRun/TeacherWelcomeScreen.js
@@ -18,6 +18,8 @@ import QcParentScreen from 'screens/QcParentScreen';
 //to function dynamically
 export class TeacherWelcomeScreen extends QcParentScreen {
 
+    name = "TeacherWelcomeScreen";
+
     //--- state captures the inputted user info ------------------
     state = {
         name: this.props.name,
@@ -105,7 +107,7 @@ export class TeacherWelcomeScreen extends QcParentScreen {
                     cancelText={strings.Cancel}
                     setModalVisible={this.setModalVisible.bind(this)}
                     onImageSelected={this.onImageSelected.bind(this)}
-                    screen={this.constructor.name}
+                    screen={this.name}
                 />
 
                 <View style={styles.picContainer}>
@@ -129,7 +131,7 @@ export class TeacherWelcomeScreen extends QcParentScreen {
                         onImageSelected={this.onImageSelected.bind(this)}
                         onShowMore={() => this.setModalVisible(true)}
                         selectedImageIndex={this.state.profileImageId}
-                        screen={this.constructor.name}
+                        screen={this.name}
                     />
                 </View>
                 <View style={styles.buttonsContainer}>
@@ -137,7 +139,7 @@ export class TeacherWelcomeScreen extends QcParentScreen {
                         text={strings.Save}
                         onPress={() => this.saveProfileInfo(0)} //to-do: Make sure that teacher ID 
                     //is passed instead of 0
-                        screen={this.constructor.name}
+                        screen={this.name}
                     />
                 </View>
                 <View style={styles.filler}></View>

--- a/Dev/QConnect/src/screens/QcParentScreen.js
+++ b/Dev/QConnect/src/screens/QcParentScreen.js
@@ -10,7 +10,7 @@ class QcParentScreen extends FontLoadingComponent {
 
         Analytics.record({
             name: analyticsEvents.screen_loaded,
-            attributes: { screen: this.constructor.name }
+            attributes: { screen: this.name }
         })
     }
 }

--- a/Dev/QConnect/src/screens/StudentProfile/StudentProfileScreen.js
+++ b/Dev/QConnect/src/screens/StudentProfile/StudentProfileScreen.js
@@ -16,6 +16,8 @@ import QcParentScreen from 'screens/QcParentScreen';
 
 class StudentProfileScreen extends QcParentScreen {
 
+  name = "StudentProfileScreen";
+
   state = {
     isDialogVisible: false,
     averageGrade: 0,
@@ -105,7 +107,7 @@ class StudentProfileScreen extends QcParentScreen {
           cancelText="Cancel"
           setModalVisible={this.setModalVisible.bind(this)}
           onImageSelected={this.onImageSelected.bind(this)}
-          screen={this.constructor.name}
+          screen={this.name}
         />
 
         {this.state.fontLoaded ? (

--- a/Dev/QConnect/src/screens/TeacherScreens/AddClass/AddClassScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/AddClass/AddClassScreen.js
@@ -21,6 +21,8 @@ import strings from '../../../../config/strings';
 import QcParentScreen from "screens/QcParentScreen";
 
 export class AddClassScreen extends QcParentScreen {
+  name = "AddClassScreen";
+
   //----------------------- state -------------------------------------
   state = {
     className: "",
@@ -104,7 +106,7 @@ render() {
             cancelText={strings.Cancel}
             setModalVisible={this.setModalVisible.bind(this)}
             onImageSelected={this.onImageSelected.bind(this)}
-            screen={this.constructor.name}
+            screen={this.name}
           />
 
           <View style={styles.picContainer}>
@@ -133,7 +135,7 @@ render() {
               onPress={() => {
                 this.addNewClass();
               }}
-              screen={this.constructor.name}
+              screen={this.name}
             />
           </View>
         </View>

--- a/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassAttendanceScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassAttendanceScreen.js
@@ -14,6 +14,8 @@ import mapStateToCurrentClassProps from 'screens/TeacherScreens/helpers/mapState
 import QcParentScreen from 'screens/QcParentScreen';
 
 export class ClassAttendanceScreen extends QcParentScreen {
+    name = "ClassAttendanceScreen";
+    
     todaysDate = this.props.defaultDate ? this.props.defaultDate : new Date().toLocaleDateString("en-US")
     state = {
         selectedStudents: [],
@@ -128,7 +130,7 @@ export class ClassAttendanceScreen extends QcParentScreen {
                     text={strings.SaveAttendance}
                     onPress={() => this.saveAttendance()}
                     style={{paddingRight: 30}}
-                    screen={this.constructor.name}
+                    screen={this.name}
                 />
             </View>
             {this.props.students.map((student, i) => {

--- a/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassEditScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassEditScreen.js
@@ -18,6 +18,7 @@ import QcParentScreen from "screens/QcParentScreen";
 
 export class ClassEditScreen extends QcParentScreen {
 
+  name = "ClassEditScreen";
 
   // ---------- Helpers to initialize random suggested student images --------------
   //  2 gender neutral images, one female, and one male
@@ -151,7 +152,7 @@ export class ClassEditScreen extends QcParentScreen {
             cancelText="Cancel"
             setModalVisible={this.setModalVisible.bind(this)}
             onImageSelected={this.onImageSelected.bind(this)}
-            screen={this.constructor.name}
+            screen={this.name}
           />
 
           <View ID={classIndex} style={styles.inputContainer}>
@@ -168,12 +169,12 @@ export class ClassEditScreen extends QcParentScreen {
               onImageSelected={this.onImageSelected.bind(this)}
               onShowMore={() => this.setModalVisible(true)}
               selectedImageIndex={this.state.profileImageId}
-              screen={this.constructor.name}
+              screen={this.name}
             />
             <QcActionButton
               text={strings.AddStudent}
               onPress={() => this.addNewStudent(classIndex)}
-              screen={this.constructor.name}
+              screen={this.name}
             />
           </View>
           <FlatList

--- a/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassMainScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassMainScreen.js
@@ -10,6 +10,8 @@ import QcParentScreen from "screens/QcParentScreen";
 
 export class ClassMainScreen extends QcParentScreen {
 
+  name = "ClassMainScreen";
+  
   async componentDidMount() {
     super.componentDidMount();
     //This may not be the eventual right approach here.. but this is a current mitigation to the 

--- a/Dev/QConnect/src/screens/TeacherScreens/LeftNavPane.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/LeftNavPane.js
@@ -13,6 +13,8 @@ import strings from '../../../config/strings';
 import QcParentScreen from "screens/QcParentScreen";
 
 class LeftNavPane extends QcParentScreen{
+  name = "LeftNavPane";
+  
   openClass = (i, className) => {
     //update current class index in redux
     this.props.saveTeacherInfo(

--- a/Dev/QConnect/src/screens/TeacherScreens/TeacherProfile/TeacherProfileScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/TeacherProfile/TeacherProfileScreen.js
@@ -16,6 +16,8 @@ import QcParentScreen from 'screens/QcParentScreen';
 //To-Do: All info in this class is static, still needs to be hooked up to data base in order
 //to function dynamically
 export class TeacherProfileScreen extends QcParentScreen {
+    name = "TeacherProfileScreen";
+
     state = {
         name: this.props.name,
         phoneNumber: this.props.phoneNumber,
@@ -90,7 +92,7 @@ export class TeacherProfileScreen extends QcParentScreen {
                         cancelText={strings.Cancel}
                         setModalVisible={this.setModalVisible.bind(this)}
                         onImageSelected={this.onImageSelected.bind(this)}
-                        screen={this.constructor.name}
+                        screen={this.name}
                     />
                     <View style={styles.picContainer}>
                         <Image
@@ -113,12 +115,12 @@ export class TeacherProfileScreen extends QcParentScreen {
                         <QcActionButton
                             text={strings.Cancel}
                             onPress={() => this.resetProfileInfo()}
-                            screen={this.constructor.name}
+                            screen={this.name}
                         />
                         <QcActionButton
                             text={strings.Save}
                             onPress={() => this.saveProfileInfo(0)} //to-do: Make sure that teacher ID 
-                            screen={this.constructor.name}
+                            screen={this.name}
                         //is passed instead of 0
                         />
                     </View>


### PR DESCRIPTION
I started seeing in the telemetry some weird names of loaded screens, and after investigation it turns out that we can't rely to this.constructor.name to capture the screen name.

We used to rely on contructor.name to automatically get the name of the loaded screen for analytics. Unfortunately according to ES6 specs this only works on non compiled JS.

I switched to explicity setting a varialbe with the name of each screen.