### PR TITLE
Fixed layout and non responsive buttons in the login and create account flow

### DIFF
--- a/Dev/QConnect/config/strings.js
+++ b/Dev/QConnect/config/strings.js
@@ -31,6 +31,7 @@ export default {
     CreateAccount: 'CREATE ACCOUNT',
     AuthorizationCode: "Authorization Code",
     Confirm: "Confirm",
+    ConfirmAccount: "Confirm Account",
     ErrorSigningUp: "Error signing up",
     ErrorSigningIn: "Error signing in",
     InvalidPhoneNumber: "The phone number is invalid. Please enter a valid phone number.",

--- a/Dev/QConnect/src/model/actions/authActions.js
+++ b/Dev/QConnect/src/model/actions/authActions.js
@@ -23,7 +23,6 @@ import { Auth } from 'aws-amplify'
 import strings from 'config/strings'
 import Analytics from '@aws-amplify/analytics';
 import analyticsEvents from 'config/analyticsEvents'
-import awsconfig from '../../../aws-exports';
 
 function signUp() {
   return {
@@ -70,7 +69,7 @@ export function createUser(username, password, email, phone_number) {
       console.log('error signing up: ', err)
       Analytics.record({
         name: analyticsEvents.create_user_failed,
-        attributes:  err 
+        attributes:  {...err} 
       })
 
       Alert.alert(strings.ErrorSigningUp, "" + (err.message || err))
@@ -122,7 +121,7 @@ export function authenticate(username, password, navigation, nextScreenName) {
       .catch(err => {
         Analytics.record({
           name: analyticsEvents.login_failed,
-          attributes:  err 
+          attributes:  {...err} 
         })
 
         Alert.alert(strings.ErrorSigningIn, "" + (err.message || err))
@@ -159,7 +158,7 @@ export function confirmUserSignUp(username, password, authCode, navigation, next
         console.log('error signing up: ', err)
         Analytics.record({
           name: analyticsEvents.confirm_new_user_failed,
-          attributes:  err 
+          attributes:  {...err} 
         })
   
         Alert.alert(strings.ErrorSigningUp, "" + (err.message || err))

--- a/Dev/QConnect/src/model/actions/authActions.js
+++ b/Dev/QConnect/src/model/actions/authActions.js
@@ -72,7 +72,9 @@ export function createUser(username, password, email, phone_number) {
         attributes:  {...err} 
       })
 
-      Alert.alert(strings.ErrorSigningUp, "" + (err.message || err))
+      setTimeout(() => {
+        Alert.alert(strings.ErrorSigningUp, "" + (err.message || err))
+      }, 100);
       dispatch(signUpFailure(err))
     });
   }
@@ -161,7 +163,9 @@ export function confirmUserSignUp(username, password, authCode, navigation, next
           attributes:  {...err} 
         })
   
-        Alert.alert(strings.ErrorSigningUp, "" + (err.message || err))
+        setTimeout(() => {
+          Alert.alert(strings.ErrorSigningUp, "" + (err.message || err))
+        }, 100);
         dispatch(confirmSignUpFailure(err))
       });
   }

--- a/Dev/QConnect/src/screens/AuthenticationScreens/ButtonSubmit.js
+++ b/Dev/QConnect/src/screens/AuthenticationScreens/ButtonSubmit.js
@@ -15,7 +15,8 @@ import {
 import colors from 'config/colors'
 import Analytics from '@aws-amplify/analytics';
 import analyticsEvents from 'config/analyticsEvents'
-import awsconfig from '../../../aws-exports';
+import SignupSection from './SignupSection';
+
 
 const DEVICE_WIDTH = Dimensions.get('window').width;
 const DEVICE_HEIGHT = Dimensions.get('window').height;
@@ -111,6 +112,7 @@ export default class ButtonSubmit extends Component {
           <Animated.View
             style={[styles.circle, {transform: [{scale: changeScale}]}]}
           />
+          
         </Animated.View>
       </View>
     );
@@ -119,18 +121,19 @@ export default class ButtonSubmit extends Component {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    marginTop: 20,
     alignItems: 'center',
     justifyContent: 'flex-start',
-    backgroundColor: 'transparent'
+    backgroundColor: 'transparent',
   },
   button: {
     alignItems: 'center',
+    alignSelf: 'stretch',
     justifyContent: 'center',
     backgroundColor: colors.primaryLight,
     height: MARGIN,
     borderRadius: 20,
-    zIndex: 100,
+    zIndex: 10,
   },
   circle: {
     height: MARGIN,
@@ -140,7 +143,7 @@ const styles = StyleSheet.create({
     borderColor: colors.primaryLight,
     borderRadius: 100,
     alignSelf: 'center',
-    zIndex: 99,
+    zIndex: 9,
     backgroundColor: colors.primaryLight,
   },
   text: {

--- a/Dev/QConnect/src/screens/AuthenticationScreens/Form.js
+++ b/Dev/QConnect/src/screens/AuthenticationScreens/Form.js
@@ -42,6 +42,7 @@ export default class Form extends Component {
           autoCorrect={false}
           onChangeText={this.props.onUserNameChange}
         />
+        <View style={styles.container}>
         <UserInput
           source={passwordImg}
           secureTextEntry={this.state.showPass}
@@ -57,6 +58,7 @@ export default class Form extends Component {
           onPress={this.showPass}>
           <Image source={eyeImg} style={styles.iconEye} />
         </TouchableOpacity>
+        </View>
       </KeyboardAvoidingView>
     );
   }
@@ -71,8 +73,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   btnEye: {
+    top: 6,
     position: 'absolute',
-    top: 60,
     right: 28,
   },
   iconEye: {

--- a/Dev/QConnect/src/screens/AuthenticationScreens/LoginScreen.js
+++ b/Dev/QConnect/src/screens/AuthenticationScreens/LoginScreen.js
@@ -71,7 +71,7 @@ class LoginScreen extends Component {
       isAuthenticating,
       loginError,
       showSignInConfirmationModal
-    }} = this.props
+    } } = this.props
 
     return (
       <View style={{ flex: 1 }}>
@@ -84,17 +84,15 @@ class LoginScreen extends Component {
             onUserNameChange={this.onUserNameChange.bind(this)}
             onPwChange={this.onPwChange.bind(this)}
           />
-
-          <SignupSection 
-            onCreateAccount={this.onCreateAccount.bind(this)}
-          />
           <ButtonSubmit
-            style={{top: -95}}
             text={strings.Login}
             onSubmit={this.signIn.bind(this)}
             navigation={this.props.navigation}
             screen="LoginScreen" />
-        </ImageBackground>
+          <SignupSection
+            onCreateAccount={this.onCreateAccount.bind(this)}
+          />
+         </ImageBackground>
       </View>
     );
   }

--- a/Dev/QConnect/src/screens/AuthenticationScreens/SignupSection.js
+++ b/Dev/QConnect/src/screens/AuthenticationScreens/SignupSection.js
@@ -25,12 +25,11 @@ const DEVICE_HEIGHT = Dimensions.get('window').height;
 
 const styles = StyleSheet.create({
   container: {
+    marginTop: 5,
     flex: 1,
-    top: 60,
     width: DEVICE_WIDTH,
     flexDirection: 'row',
     justifyContent: 'space-around',
-    zIndex: 800
   },
   text: {
     color: colors.black,

--- a/Dev/QConnect/src/screens/FirstRun/TeacherWelcomeScreen.js
+++ b/Dev/QConnect/src/screens/FirstRun/TeacherWelcomeScreen.js
@@ -258,7 +258,9 @@ export class TeacherWelcomeScreen extends QcParentScreen {
               !signUpErrorMessage && 
               !signUpError && (
                 <Modal
-                  transparent={true}>
+                  transparent={true}
+                  onRequestClode={()=>{}}>
+                  
                   <View style={styles.modal}>
                     <Text style={styles.confirmationMessage}>Please enter the validation code sent to your email</Text>
                     <Input

--- a/Dev/QConnect/src/screens/FirstRun/TeacherWelcomeScreen.js
+++ b/Dev/QConnect/src/screens/FirstRun/TeacherWelcomeScreen.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, View, Image, Text, TouchableWithoutFeedback, KeyboardAvoidingView, Keyboard, Alert, Modal, ScrollView } from "react-native";
+import { StyleSheet, View, Image, Text, TouchableWithoutFeedback, KeyboardAvoidingView, Keyboard, Alert, Modal, ScrollView, LayoutAnimation, Platform } from "react-native";
 import QcActionButton from "components/QcActionButton";
 import Toast, { DURATION } from "react-native-easy-toast";
 import { saveTeacherInfo } from "model/actions/saveTeacherInfo";
@@ -22,12 +22,14 @@ const initialState = {
   password: ''
 }
 
-
-
 //To-Do: All info in this class is static, still needs to be hooked up to data base in order
 //to function dynamically
 export class TeacherWelcomeScreen extends QcParentScreen {
   state = initialState;
+
+  componentWillUnmount() {
+    this.setState({ isModalVisible: false });
+  }
 
   signUp(username, password, email, phone_number) {
     this.props.createUser(username, password, email, phone_number)
@@ -125,40 +127,52 @@ export class TeacherWelcomeScreen extends QcParentScreen {
   saveProfileInfo = teacherID => {
     const { name, phoneNumber, emailAddress, password } = this.state;
 
-    if (!name || 
+    //Reset the confirmation dialog state cancelation state
+    //In case user canceled the confirmation code dialog before, we reset that state so we can show the dialog again upon new submission
+    this.setState({ confirmationModalCanceled: false });
+
+    // trick to remove modalVisible and hilightedImagesIndices from state and pass in everything else
+    const { modalVisible, highlightedImagesIndices, ...params } = this.state;
+
+    this.signUp(emailAddress, password, emailAddress, phoneNumber);
+
+    //generate a new id if this is a new teacher 
+    if (teacherID === undefined) {
+      var nanoid = require('nanoid/non-secure')
+      teacherID = nanoid()
+    }
+
+    // save the relevant teacher properties
+    this.props.saveTeacherInfo(
+      { teacherID, ...params }
+    );
+  };
+
+  //Creates new account, or launches confirmation dialog if account was created but not confirmed yet.
+  onCreateOrConfirmAccount() {
+    //validate entries first
+    const { name, phoneNumber, emailAddress, password } = this.state;
+    if (!name ||
       !phoneNumber ||
-      !emailAddress || 
-      !password || 
+      !emailAddress ||
+      !password ||
       name.trim() === ""
       || phoneNumber.trim() === ""
       || emailAddress.trim() === ""
       || password.trim() === "") {
-        Alert.alert(strings.Whoops, strings.PleaseMakeSureAllFieldsAreFilledOut);
-    } else if(!this.state.isPhoneValid){
+      Alert.alert(strings.Whoops, strings.PleaseMakeSureAllFieldsAreFilledOut);
+    } else if (!this.state.isPhoneValid) {
       Alert.alert(strings.Whoops, strings.InvalidPhoneNumber);
     } else {
-      //Reset the confirmation dialog state cancelation state
-      //In case user canceled the confirmation code dialog before, we reset that state so we can show the dialog again upon new submission
-      this.setState({ confirmationModalCanceled: false });
-
-      // trick to remove modalVisible and hilightedImagesIndices from state and pass in everything else
-      const { modalVisible, highlightedImagesIndices, ...params } = this.state;
-
-
-      this.signUp(emailAddress, password, emailAddress, phoneNumber);
-
-      //generate a new id if this is a new teacher 
-      if (teacherID === undefined) {
-        var nanoid = require('nanoid/non-secure')
-        teacherID = nanoid()
+      //if the account is already created yet we need to confirm, show confirmation dialog
+      if (this.props.auth.showSignUpConfirmationModal) {
+        this.setState({ showSignUpConfirmationModal: true, confirmationModalCanceled: false });
+      } else {
+        //else, create account and save profile info
+        this.saveProfileInfo()
       }
-
-      // save the relevant teacher properties
-      this.props.saveTeacherInfo(
-        { teacherID, ...params }
-      );
     }
-  };
+  }
 
   //------ event handlers to capture user input into state as user modifies the entries -----
   onNameChanged = value => {
@@ -182,6 +196,12 @@ export class TeacherWelcomeScreen extends QcParentScreen {
     this.setState({ authCode: value })
   }
 
+  componentWillMount() {
+    if (Platform.OS === 'ios') {
+      LayoutAnimation.easeInEaseOut();
+    }
+  }
+
   //---------- render method ---------------------------------
   // The following custom components are used below:
   // -    ImageSelectionModal: implements the pop up modal to allow users to customize their avatar
@@ -192,104 +212,99 @@ export class TeacherWelcomeScreen extends QcParentScreen {
     const { auth: {
       showSignUpConfirmationModal,
       isAuthenticating,
-      signUpError,
-      signUpErrorMessage,
-      confirmedSignUp
     } } = this.props
 
     return (
       <View><ScrollView>
-      <KeyboardAvoidingView style={styles.container} behavior="padding">
-        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-          <View style={styles.container}>
-            <ImageSelectionModal
-              visible={this.state.modalVisible}
-              images={teacherImages.images}
-              cancelText={strings.Cancel}
-              setModalVisible={this.setModalVisible.bind(this)}
-              onImageSelected={this.onImageSelected.bind(this)}
-              screen={this.name}
-            />
-
-            <View style={styles.picContainer}>
-              <FadeInView
-                style={{ alignItems: 'center', justifyContent: 'center' }}>
-                <Image
-                  style={styles.welcomeImage}
-                  source={require("assets/images/salam.png")}
-                />
-                <Text style={styles.quote}>{strings.TeacherWelcomeMessage}</Text>
-              </FadeInView>
-
-            </View>
-            <View style={styles.editInfo} behavior="padding">
-              <TeacherInfoEntries
-                name={this.state.name}
-                phoneNumber={this.state.phoneNumber}
-                emailAddress={this.state.emailAddress}
-                password={this.state.password}
-                onNameChanged={this.onNameChanged}
-                onPhoneNumberChanged={this.onPhoneNumberChanged}
-                onEmailAddressChanged={this.onEmailAddressChanged}
-                showPasswordField={true}
-                onPasswordChanged={this.onPasswordChanged}
-              />
-              <ImageSelectionRow
+        <KeyboardAvoidingView style={styles.container} behavior="padding">
+          <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+            <View style={styles.container}>
+              <ImageSelectionModal
+                visible={this.state.modalVisible}
                 images={teacherImages.images}
-                highlightedImagesIndices={this.state.highlightedImagesIndices}
+                cancelText={strings.Cancel}
+                setModalVisible={this.setModalVisible.bind(this)}
                 onImageSelected={this.onImageSelected.bind(this)}
-                onShowMore={() => this.setModalVisible(true)}
-                selectedImageIndex={this.state.profileImageId}
                 screen={this.name}
               />
-            </View>
-            <View style={styles.buttonsContainer}>
-              <QcActionButton
-                text={strings.CreateAccount}
-                onPress={() => this.saveProfileInfo()} 
-                isLoading={isAuthenticating}
-                screen={this.name}
-              />
-            </View>
-            <View style={styles.filler} />
-            {
-              showSignUpConfirmationModal &&
-              !this.state.confirmationModalCanceled && 
-              !signUpErrorMessage && 
-              !signUpError && (
-                <Modal
-                  transparent={true}
-                  onRequestClode={()=>{}}>
-                  
-                  <View style={styles.modal}>
-                    <Text style={styles.confirmationMessage}>Please enter the validation code sent to your email</Text>
-                    <Input
-                      placeholder={strings.AuthorizatonConde}
-                      type='authCode'
-                      keyboardType='numeric'
-                      onChangeText={this.onAuthCodeChanged}
-                      value={this.state.authCode}
-                      keyboardType='numeric'
-                    />
-                    <View style={{flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal: 5 }}>
-                      <QcActionButton
-                        text={strings.Confirm}
-                        onPress={this.confirm.bind(this)}
-                        isLoading={isAuthenticating}
+
+              <View style={styles.picContainer}>
+                <FadeInView
+                  style={{ alignItems: 'center', justifyContent: 'center' }}>
+                  <Image
+                    style={styles.welcomeImage}
+                    source={require("assets/images/salam.png")}
+                  />
+                  <Text style={styles.quote}>{strings.TeacherWelcomeMessage}</Text>
+                </FadeInView>
+
+              </View>
+              <View style={styles.editInfo} behavior="padding">
+                <TeacherInfoEntries
+                  name={this.state.name}
+                  phoneNumber={this.state.phoneNumber}
+                  emailAddress={this.state.emailAddress}
+                  password={this.state.password}
+                  onNameChanged={this.onNameChanged}
+                  onPhoneNumberChanged={this.onPhoneNumberChanged}
+                  onEmailAddressChanged={this.onEmailAddressChanged}
+                  showPasswordField={true}
+                  onPasswordChanged={this.onPasswordChanged}
+                />
+                <ImageSelectionRow
+                  images={teacherImages.images}
+                  highlightedImagesIndices={this.state.highlightedImagesIndices}
+                  onImageSelected={this.onImageSelected.bind(this)}
+                  onShowMore={() => this.setModalVisible(true)}
+                  selectedImageIndex={this.state.profileImageId}
+                  screen={this.name}
+                />
+              </View>
+              <View style={styles.buttonsContainer}>
+                <QcActionButton
+                  text={showSignUpConfirmationModal ? strings.ConfirmAccount : strings.CreateAccount}
+                  onPress={() => this.onCreateOrConfirmAccount()}
+                  isLoading={isAuthenticating}
+                  screen={this.name}
+                />
+              </View>
+              <View style={styles.filler} />
+              {
+                showSignUpConfirmationModal &&
+                !this.state.confirmationModalCanceled && (
+                  <Modal
+                    transparent={true}
+                    onRequestClode={() => { }}>
+
+                    <View style={styles.modal}>
+                      <Text style={styles.confirmationMessage}>Please enter the validation code sent to your email</Text>
+                      <Input
+                        placeholder={strings.AuthorizatonConde}
+                        type='authCode'
+                        keyboardType='numeric'
+                        onChangeText={this.onAuthCodeChanged}
+                        value={this.state.authCode}
+                        keyboardType='numeric'
                       />
-                      <QcActionButton
-                        text={strings.Cancel}
-                        onPress={() => { this.setState({ confirmationModalCanceled: true }) }}
-                      />
+                      <View style={{ flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal: 5 }}>
+                        <QcActionButton
+                          text={strings.Confirm}
+                          onPress={this.confirm.bind(this)}
+                          isLoading={isAuthenticating}
+                        />
+                        <QcActionButton
+                          text={strings.Cancel}
+                          onPress={() => { this.setState({ confirmationModalCanceled: true }) }}
+                        />
+                      </View>
                     </View>
-                  </View>
-                </Modal>
-              )
-            }
-            <Toast ref="toast" />
-          </View>
-        </TouchableWithoutFeedback>
-      </KeyboardAvoidingView>
+                  </Modal>
+                )
+              }
+              <Toast ref="toast" />
+            </View>
+          </TouchableWithoutFeedback>
+        </KeyboardAvoidingView>
       </ScrollView></View>
     );
   }


### PR DESCRIPTION
Create Account button was not responsive on Android due to zIndex mismatch. Fixed the Login dialog flow to fix the problem as well as make the flow flex based.
Fixed an issue in iOS in the TeacherWelcomeScreen where there are cases where the confirm account dialog becomes non responsive if an error dialog shows up on top of it. This is due to this issue: https://github.com/facebook/react-native/issues/10471
I also modified the logic of the teacher welcome page so that when user dismisses the account confirmation dialog, the button will now say "confirm account" and will only go through the confirmation flow and not attempt to re-create the account.

Please test these screens as much as you can since there is quite a bit of logic and we need a lot of validation to flush out all bugs.

Thanks,