### PR TITLE
Handled the case of when a user who hasn't confirmed their email yet attempts to login to the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Dev/QConnect/yarn-error.log
 
 Dev/QConnect/get-khaled-changes.cmd
 Dev/QConnect/assets/bookIcon.png.pp3
+Dev/QConnect/.DS_Store
+Dev/.DS_Store

--- a/Dev/QConnect/src/model/reducers/auth.js
+++ b/Dev/QConnect/src/model/reducers/auth.js
@@ -96,7 +96,6 @@ export default (state = initialState, action) => {
       return {
         isAuthenticating: false,
         user: action.user,
-        showSignInConfirmationModal: true
       }
     case actionTypes.LOG_IN_FAILURE:
       return {

--- a/Dev/QConnect/src/screens/AuthenticationScreens/LoginScreen.js
+++ b/Dev/QConnect/src/screens/AuthenticationScreens/LoginScreen.js
@@ -1,14 +1,17 @@
 import React, { Component } from 'react';
-import { View, ImageBackground, Dimensions, StyleSheet } from 'react-native';
+import { View, ImageBackground, Dimensions, StyleSheet, Modal, Text } from 'react-native';
 import Form from './Form';
 import ButtonSubmit from './ButtonSubmit';
 import SignupSection from './SignupSection';
 import QcAppBanner from 'components/QcAppBanner';
-import { authenticate, confirmUserLogin } from 'model/actions/authActions'
+import { authenticate, confirmUserLogin, confirmUserSignUp, logOut } from 'model/actions/authActions'
+import { addTeacher} from 'model/actions/addTeacher'
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import strings from "config/strings";
 import colors from "config/colors";
+import { Input } from 'react-native-elements'
+import QcActionButton from "components/QcActionButton";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 const SCREEN_HEIGHT = Dimensions.get("window").height;
@@ -23,6 +26,11 @@ class LoginScreen extends Component {
     this._isMounted = true;
   }
 
+  componentWillMount() {
+    //clear up old auth state, since the user is logging in again.
+    this.props.logOut();
+  }
+
   componentWillUnmount() {
     this._isMounted = false;
   }
@@ -32,7 +40,8 @@ class LoginScreen extends Component {
     password: "",
     email: "",
     phone_number: "",
-    authCode: ""
+    authCode: "",
+    confirmationModalCanceled: false,
   };
 
   onUserNameChange = (_username) => {
@@ -52,8 +61,32 @@ class LoginScreen extends Component {
   }
 
   signIn() {
+    //Reset the confirmation dialog state cancelation state
+    //In case user canceled the confirmation code dialog before, we reset that state so we can show the dialog again upon new submission
+    this.setState({ confirmationModalCanceled: false });
+
     const { username, password } = this.state
     this.props.authenticate(username, password, this.props.navigation, "App")
+  }
+
+  confirm() {
+    const { authCode, username, password } = this.state;
+
+    //todo: confirm that the emailAddress that was saved to db earlier is the same as service, 
+    // if not, check if teacher is created already on service, and pull data from service then.
+    // for now, I'll just use whatever was saved locally as a stop gap
+    const { profileImageId, name, phoneNumber} = this.props;
+
+    this.props.confirmUserSignUp(
+      name,
+      username, 
+      password, 
+      authCode, 
+      this.props.navigation, 
+      'AddClass', 
+      this.props.addTeacher,
+      phoneNumber, 
+      profileImageId)
   }
 
   onForgotPassword = () => {
@@ -61,6 +94,11 @@ class LoginScreen extends Component {
   }
 
   render() {
+    const { auth: {
+      showSignUpConfirmationModal,
+      isAuthenticating,
+    } } = this.props
+
     return (
       <View style={{ flex: 1 }}>
         <ImageBackground source={BG_IMAGE} style={styles.bgImage}>
@@ -82,6 +120,38 @@ class LoginScreen extends Component {
             onForgotPassword={this.onForgotPassword.bind(this)}
           />
          </ImageBackground>
+        {
+          showSignUpConfirmationModal &&
+          !this.state.confirmationModalCanceled && (
+            <Modal
+              transparent={true}
+              onRequestClode={() => { }}>
+
+              <View style={styles.modal}>
+                <Text style={styles.confirmationMessage}>Please enter the validation code sent to your email</Text>
+                <Input
+                  placeholder={strings.AuthorizatonConde}
+                  type='authCode'
+                  keyboardType='numeric'
+                  onChangeText={this.onAuthCodeChanged}
+                  value={this.state.authCode}
+                  keyboardType='numeric'
+                />
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal: 5 }}>
+                  <QcActionButton
+                    text={strings.Confirm}
+                    onPress={this.confirm.bind(this)}
+                    isLoading={isAuthenticating}
+                  />
+                  <QcActionButton
+                    text={strings.Cancel}
+                    onPress={() => { this.setState({ confirmationModalCanceled: true }) }}
+                  />
+                </View>
+              </View>
+            </Modal>
+          )
+        }
       </View>
     );
   }
@@ -129,14 +199,32 @@ const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
       authenticate,
-      confirmUserLogin
+      confirmUserLogin,
+      confirmUserSignUp,
+      logOut,
+      addTeacher,
     },
     dispatch
   );
 
-const mapStateToProps = state => ({
-  auth: state.auth
-})
+const mapStateToProps = state => {
+  
+  //todo: do not hardcode the default image id. Have it defined as a constant somewhere.
+  //if a teacher object exists in the local database, let's pick profile image from there
+  // this is to cover the case where the user tried to create a teacher, then closed the app before confirming their email.
+  // next time they launch the app and login, we need to re-send their profile info to the service 
+  // to create the teacher object (we can only create a teacher after they have been successfully confirmed their email)
+  imgId = state.data.teacher? state.data.teacher.profileImageId : 1;
+  name = state.data.teacher? state.data.teacher.name : "";
+  phoneNumber = state.data.teacher? state.data.teacher.phoneNumber : "";
+
+  return {
+    auth: state.auth,
+    profileImageId: imgId,
+    phoneNumber: phoneNumber,
+    name: name
+  }
+}
 
 
 export default connect(

--- a/Dev/QConnect/src/screens/SettingsScreen/allSettingsScreen.js
+++ b/Dev/QConnect/src/screens/SettingsScreen/allSettingsScreen.js
@@ -5,8 +5,11 @@ import colors from 'config/colors';
 import { Icon } from 'react-native-elements';
 import strings from 'config/strings';
 import QcParentScreen from "screens/QcParentScreen";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import {reset} from 'model/actions/reset'
 
-export default class AllSettingsScreen extends QcParentScreen {
+export class AllSettingsScreen extends QcParentScreen {
 
     name = "AllSettingsScreen";
 
@@ -45,6 +48,16 @@ export default class AllSettingsScreen extends QcParentScreen {
                         iconStyle={{ marginRight: 20 }}
                         color={colors.primaryDark} />
                 </TouchableOpacity>
+                {//todo: debug only. We should put behind a flight or a debug flag. For now, do not push to prod with this,
+                // at least comment out the section below before pushing to prod.}
+                <TouchableOpacity style={[styles.cardStyle, { marginTop: 25 }]} onPress={() => this.props.reset()}>
+                    <Text style={styles.textStyle}>Reset database (debug only)</Text>
+                    <Icon
+                        name='angle-right'
+                        type='font-awesome'
+                        iconStyle={{ marginRight: 20 }}
+                        color={colors.primaryDark} />
+                </TouchableOpacity>
             </View>
 
         )
@@ -75,3 +88,20 @@ const styles = StyleSheet.create({
         marginLeft: 20
     },
 })
+
+const mapStateToProps = (state) => {
+    return {}
+  };
+  
+  const mapDispatchToProps = dispatch =>
+    bindActionCreators(
+      {
+        reset
+      },
+      dispatch
+    );
+  
+  export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(AllSettingsScreen);

--- a/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassMainScreen.js
+++ b/Dev/QConnect/src/screens/TeacherScreens/ClassTabs/ClassMainScreen.js
@@ -41,7 +41,7 @@ export class ClassMainScreen extends QcParentScreen {
         </View>
       )
     }
-    else if (this.props.students.length === 0) {
+    else if (!this.props.students || this.props.students.length === 0) {
       /**
        * ------Overview:
        * The Page will display a message that will redirect the teacher to the 


### PR DESCRIPTION
We now show them the confirmation dialog as part of the login screen.

Please note that we aren't able to create a teacher entity in the server until their username is fully created and confirmed. That's why I now only save to local db when teacher create a new account but are not confirmed yet, and when user confirms their email, I then push it to the server.

I also added an option under setting to reset database (for ease of debugging). However, we should put this under a debug flight so it doesn't surface in the production version.